### PR TITLE
setup: create binaries dir during setup

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -5,6 +5,7 @@ cmds := "github.com/quay/clair/v4/cmd/clair github.com/quay/clair/v4/cmd/clairct
 setup: && fetch
 	grep -q '{{mrconfig}}' ~/.mrtrust || echo '{{mrconfig}}' >> ~/.mrtrust
 	mr checkout
+	mkdir -p {{GOBIN}}
 
 fetch:
 	mr -q fetch


### PR DESCRIPTION
Added this to avoid go throwing an error about writing multiple packages to a non-directory.

Error:
```
go build -trimpath -o /<go-path>/src/github.com/quay/clair-workspace/bin github.com/quay/clair/v4/cmd/clair github.com/quay/clair/v4/cmd/clairctl
go: cannot write multiple packages to non-directory /<go-path>/src/github.com/quay/clair-workspace/bin
```